### PR TITLE
Scripts to delete odc product

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,31 @@ Scripts for indexing data into ODC instances
 
 # GDAL3
 Please note - we are aware that using these scripts with GDAL 3.0+ can cause Latitudes and Longitudes to become transposed. When using these scripts, please use a python environment with an earlier version of GDAL.
+
+
+# odc-product-delete (In beta)
+SQL scripts to delete ODC products and related records in ODC, Explorer and OWS DB. Each script takes product_name as an input parameter.
+
+Usage:
+```
+psql -v product_name=<product-to-delete> -f <scriptname.sql> -h <database-hostname> <dbname>
+```
+
+- `delete_odc_product.sql` 
+    - This script will delete ODC product from ODC DB. 
+    - It deletes records from tables `agdc.dataset_source`, `agdc.dataset_location`, `agdc.dataset` and `agdc.dataset_type`.
+    - It also deletes indexes and view related to the ODC product.
+    
+- `delete_odc_product_explorer.sql` 
+    - This script will delete records related to ODC product from Explorer DB. 
+    - It deletes records from these tables `cubedash.dataset_spatial`, `cubedash.time_overview`, `cubedash.product`.
+    - Also, it refreshes materialised view `cubedash.mv_dataset_spatial_quality`.
+
+- `delete_odc_product_ows.sql`
+    - This script will delete records from tables `wms.product_ranges` and `wms.sub_product_ranges`. 
+    - This script needs to be run before `delete_odc_product.sql` as OWS DB maintains a foreign key to ODC DB.
+    - Table `agdc.dataset_type` has foreign key constraint `wms.product_ranges_id_fkey` on table `wms.product_ranges`
+
+Notes: 
+- AS ODC doesn't have product deletion feature with an intention to keep an immutable history of datasets, these scripts are created to manually delete an entire ODC Product. 
+- To be noted this scripts are still in beta testing phase.

--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ psql -v product_name=<product-to-delete> -f <scriptname.sql> -h <database-hostna
 ```
 
 - `delete_odc_product.sql` 
-    - This script will delete ODC product from ODC DB. 
+    - This script will delete a product and all datasets from an ODC DB. 
     - It deletes records from tables `agdc.dataset_source`, `agdc.dataset_location`, `agdc.dataset` and `agdc.dataset_type`.
     - It also deletes indexes and view related to the ODC product.
     
 - `delete_odc_product_explorer.sql` 
-    - This script will delete records related to ODC product from Explorer DB. 
+    - This script will delete records related to an ODC product from the Explorer Schema in the ODC DB. 
     - It deletes records from these tables `cubedash.dataset_spatial`, `cubedash.time_overview`, `cubedash.product`.
     - Also, it refreshes materialised view `cubedash.mv_dataset_spatial_quality`.
 
@@ -31,3 +31,4 @@ psql -v product_name=<product-to-delete> -f <scriptname.sql> -h <database-hostna
 Notes: 
 - AS ODC doesn't have product deletion feature with an intention to keep an immutable history of datasets, these scripts are created to manually delete an entire ODC Product. 
 - To be noted this scripts are still in beta testing phase.
+- For more detail, read [here](./odc-product-delete//README.md)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ psql -v product_name=<product-to-delete> -f <scriptname.sql> -h <database-hostna
     - This script needs to be run before `delete_odc_product.sql` as OWS DB maintains a foreign key to ODC DB.
     - Table `agdc.dataset_type` has foreign key constraint `wms.product_ranges_id_fkey` on table `wms.product_ranges`
 
-Notes: 
+### WARNING!!!
 - AS ODC doesn't have product deletion feature with an intention to keep an immutable history of datasets, these scripts are created to manually delete an entire ODC Product. 
-- To be noted this scripts are still in beta testing phase.
+- These scripts deletes data, so review the scripts thoroughly and use it very carefully!
 - For more detail, read [here](./odc-product-delete//README.md)

--- a/odc-product-delete/README.md
+++ b/odc-product-delete/README.md
@@ -39,7 +39,7 @@ Note: The `delete_odc_product.sql` is sourced from [here](https://gist.github.co
 
 ## Delete ODC Product from Explorer (`delete_odc_product_explorer.sql` )
     
-- After deletion of ODC Product, records in Cubedash tables are not cleared. 
+- After deletion of ODC Product, records in Explorer's tables are not cleared. 
 - This script will delete records related to an ODC product from the Explorer Schema in the ODC DB. 
 - It deletes records from these tables `cubedash.dataset_spatial`, `cubedash.time_overview`, `cubedash.product`.
 - Also, it refreshes materialised view `cubedash.mv_dataset_spatial_quality`.

--- a/odc-product-delete/README.md
+++ b/odc-product-delete/README.md
@@ -46,7 +46,7 @@ Note: The `delete_odc_product.sql` is sourced from [here](https://gist.github.co
 
 
 ## Steps to run scripts in sequence
-- First, run `delete_odc_product_ows.sql` if the product has not been added to OWS.
+- First, run `delete_odc_product_ows.sql` (optional: this step is not required if the product has not been added to OWS).
 ```
 psql -v product_name=<product-to-delete> -f delete_odc_product_ows.sql -h <database-hostname> <dbname>
 ```

--- a/odc-product-delete/README.md
+++ b/odc-product-delete/README.md
@@ -4,10 +4,13 @@
     - `delete_odc_product_ows.sql`
     - `delete_odc_product.sql` 
     - `delete_odc_product_explorer.sql` 
-  
-- Use with PSQL from the command line. Each script takes <product_name> and DB credentials as an input parameter.
+    
+## WARNING!!!
+- These scripts deletes data, so review the scripts thoroughly and use it very carefully!
   
 ### Usage
+- Use with PSQL from the command line. Each script takes <product_name> and DB credentials as an input parameter.
+  
 ```
 psql -v product_name=<product-to-delete> -f <scriptname.sql> -h <database-hostname> <dbname>
 ```

--- a/odc-product-delete/README.md
+++ b/odc-product-delete/README.md
@@ -17,7 +17,7 @@ psql -v product_name=<product-to-delete> -f <scriptname.sql> -h <database-hostna
 - Before deleting product from ODC DB, we need check if the product has been added to OWS.
 - If the product has been added to OWS, some of these tables have a foreign key constraint with ODC table, which will prevent rows being deleted from the main ODC database. 
 - Table `agdc.dataset_type` has foreign key constraint `wms.product_ranges_id_fkey` on table `wms.product_ranges`
-- Because of the foreign key constraint, deleting product in ODC DB will fail and raise following error:
+- Because of the foreign key constraint, deleting datasets for a product in the ODC DB will fail and raise following error:
 ```
 - ERROR:  update or DELETE on table "dataset_type" violates foreign key constraint "product_ranges_id_fkey" on table "product_ranges"
 - DETAIL:  Key (id)=(1) is still referenced from table "product_ranges".

--- a/odc-product-delete/README.md
+++ b/odc-product-delete/README.md
@@ -1,0 +1,60 @@
+# Delete ODC Product (In beta)
+
+- AS ODC doesn't have product deletion feature with an intention to keep an immutable history of datasets, following scripts are created to manually delete an entire ODC Product and related records in ODC, Explorer and OWS DB. 
+    - `delete_odc_product_ows.sql`
+    - `delete_odc_product.sql` 
+    - `delete_odc_product_explorer.sql` 
+  
+- Use with PSQL from the command line. Each script takes <product_name> and DB credentials as an input parameter.
+  
+### Usage
+```
+psql -v product_name=<product-to-delete> -f <scriptname.sql> -h <database-hostname> <dbname>
+```
+
+## Delete ODC Product from OWS (`delete_odc_product_ows.sql`)
+
+- Before deleting product from ODC DB, we need check if the product has been added to OWS.
+- If the product has been added to OWS, tables in OWS makes a foreign key constraints with ODC table. 
+- Table `agdc.dataset_type` has foreign key constraint `wms.product_ranges_id_fkey` on table `wms.product_ranges`
+- Because of the foreign key constraint, deleting product in ODC DB will fail and raise following error:
+```
+- ERROR:  update or DELETE on table "dataset_type" violates foreign key constraint "product_ranges_id_fkey" on table "product_ranges"
+- DETAIL:  Key (id)=(1) is still referenced from table "product_ranges".
+```
+- To avoid this, there is a need to run `delete_odc_product_ows.sql` script before running `delete_odc_product.sql`. 
+- This script will delete records from tables `wms.product_ranges` and `wms.sub_product_ranges`. 
+
+## Delete ODC Product from ODC DB (`delete_odc_product.sql`)
+
+- This script will delete a product and all datasets from an ODC DB. 
+- It will delete lineage records from the table `agdc.dataset_source`.
+- It will delete location records from the table `agdc.dataset_location`.
+- It deletes dataset records from the table `agdc.dataset`.
+- It deletes the product from the table `agdc.dataset_type`.
+- It also deletes indexes and view created for that ODC product.
+
+Note: The `delete_odc_product.sql` is sourced from [here](https://gist.github.com/omad/1ae3463a123f37a9acf37213bebfde86) and additional script to delete index and view are added.
+    
+
+## Delete ODC Product from Explorer (`delete_odc_product_explorer.sql` )
+    
+- After deletion of ODC Product, records in Cubedash tables are not cleared. 
+- This script will delete records related to an ODC product from the Explorer Schema in the ODC DB. 
+- It deletes records from these tables `cubedash.dataset_spatial`, `cubedash.time_overview`, `cubedash.product`.
+- Also, it refreshes materialised view `cubedash.mv_dataset_spatial_quality`.
+
+
+## Steps to run scripts in sequence
+- First, run `delete_odc_product_ows.sql` if the product has not been added to OWS.
+```
+psql -v product_name=<product-to-delete> -f delete_odc_product_ows.sql -h <database-hostname> <dbname>
+```
+- Next run `delete_odc_product.sql` to delete the ODC product in ODC DB.
+```
+psql -v product_name=<product-to-delete> -f delete_odc_product.sql -h <database-hostname> <dbname>
+```
+- Finally run `delete_odc_product_explorer.sql` to delete products from Explorer DB.
+```
+psql -v product_name=<product-to-delete> -f delete_odc_product_explorer.sql -h <database-hostname> <dbname>
+```

--- a/odc-product-delete/README.md
+++ b/odc-product-delete/README.md
@@ -15,7 +15,7 @@ psql -v product_name=<product-to-delete> -f <scriptname.sql> -h <database-hostna
 ## Delete ODC Product from OWS (`delete_odc_product_ows.sql`)
 
 - Before deleting product from ODC DB, we need check if the product has been added to OWS.
-- If the product has been added to OWS, tables in OWS makes a foreign key constraints with ODC table. 
+- If the product has been added to OWS, some of these tables have a foreign key constraint with ODC table, which will prevent rows being deleted from the main ODC database. 
 - Table `agdc.dataset_type` has foreign key constraint `wms.product_ranges_id_fkey` on table `wms.product_ranges`
 - Because of the foreign key constraint, deleting product in ODC DB will fail and raise following error:
 ```

--- a/odc-product-delete/delete_odc_product.sql
+++ b/odc-product-delete/delete_odc_product.sql
@@ -1,0 +1,112 @@
+--------------------------------------
+-- SQL to Delete a Data Cube Product
+--------------------------------------
+--
+-- Use with psql from the command line:
+--
+-- psql -v product_name=<product-to-delete> -f delete_odc_product.sql -h <database-hostname> <dbname>
+--
+
+--
+-- COUNT NUMBER OF DATASETS OF EACH TYPE (including archived)
+--
+-- select
+--   count(*),
+--   t.name
+-- from dataset
+--   left join dataset_type t on dataset.dataset_type_ref = t.id
+-- group by t.name;
+
+--
+-- CHECK FOR LINEAGE RECORDS
+--
+
+-- Are there any datasets that are descendents of this product?
+-- If so, they will need to be removed first!
+
+set search_path = 'agdc';
+
+select count(*)
+from dataset_source
+  left join dataset d on dataset_source.source_dataset_ref = d.id
+where d.dataset_type_ref = (select id
+                            from dataset_type
+                            where dataset_type.name = :'product_name');
+
+-- Are there any lineage records which need deleting?
+-- These are the lineage history of the product we're deleting.
+select count(*)
+from dataset_source
+  left join dataset d on dataset_source.dataset_ref = d.id
+where d.dataset_type_ref = (select id
+                            from dataset_type
+                            where dataset_type.name = :'product_name');
+--
+-- DELETE LINEAGE RECORDS
+--
+WITH datasets as (SELECT id
+                  FROM dataset
+                  where dataset.dataset_type_ref = (select id
+                                                    FROM dataset_type
+                                                    WHERE name = :'product_name'))
+DELETE FROM dataset_source
+USING datasets
+where dataset_source.dataset_ref = datasets.id;
+
+
+--
+-- CHECK FOR LOCATION RECORDS
+--
+select count(*)
+from dataset_location
+  left join dataset d on dataset_location.dataset_ref = d.id
+where d.dataset_type_ref = (select id
+                            from dataset_type
+                            where dataset_type.name = :'product_name');
+
+
+WITH datasets as (SELECT id
+                  FROM dataset
+                  where dataset.dataset_type_ref = (select id
+                                                    FROM dataset_type
+                                                    WHERE name = :'product_name'))
+select count(*)
+from dataset_location, datasets
+where dataset_location.dataset_ref  = datasets.id;
+
+
+--
+-- DELETE LOCATION RECORDS
+--
+WITH datasets as (SELECT id
+                  FROM dataset
+                  where dataset.dataset_type_ref = (select id
+                                                    FROM dataset_type
+                                                    WHERE name = :'product_name'))
+DELETE FROM dataset_location
+USING datasets
+where dataset_location.dataset_ref = datasets.id;
+
+--
+-- DELETE DATASET RECORDS
+--
+DELETE FROM dataset
+where dataset.dataset_type_ref = (select id
+                            from dataset_type
+                            where dataset_type.name = :'product_name');
+
+
+--
+-- FINALLY, DELETE THE PRODUCT
+--
+DELETE FROM dataset_type
+where dataset_type.name = :'product_name';
+
+-- DROP VIEW
+\set view_name 'dv_' :product_name '_dataset'
+DROP VIEW IF EXISTS :view_name;
+
+-- DROP DYNAMIC INDEXES FROM 'dataset' table
+\set index_name 'dix_' :product_name '_%'
+SELECT FORMAT('DROP INDEX CONCURRENTLY %I.%I;', schemaname, indexname) as drop_statement from pg_indexes where tablename ='dataset' and indexname like :'index_name'; \gexec
+

--- a/odc-product-delete/delete_odc_product.sql
+++ b/odc-product-delete/delete_odc_product.sql
@@ -102,11 +102,18 @@ where dataset.dataset_type_ref = (select id
 DELETE FROM dataset_type
 where dataset_type.name = :'product_name';
 
+
+--
 -- DROP VIEW
+--
 \set view_name 'dv_' :product_name '_dataset'
+
 DROP VIEW IF EXISTS :view_name;
 
--- DROP DYNAMIC INDEXES FROM 'dataset' table
-\set index_name 'dix_' :product_name '_%'
-SELECT FORMAT('DROP INDEX CONCURRENTLY %I.%I;', schemaname, indexname) as drop_statement from pg_indexes where tablename ='dataset' and indexname like :'index_name'; \gexec
 
+--
+-- DROP DYNAMIC INDEXES FROM 'dataset' table
+--
+\set index_name 'dix_' :product_name '_%'
+
+SELECT FORMAT('DROP INDEX CONCURRENTLY %I.%I;', schemaname, indexname) as drop_statement from pg_indexes where tablename ='dataset' and indexname like :'index_name'; \gexec

--- a/odc-product-delete/delete_odc_product_explorer.sql
+++ b/odc-product-delete/delete_odc_product_explorer.sql
@@ -1,0 +1,33 @@
+----------------------------------------------------------
+-- SQL to DELETE a Data Cube Product in Explorer
+----------------------------------------------------------
+
+--
+-- Use with psql from the command line:
+--
+-- psql -v product_name=<product-to-DELETE> -f delete_product_ows.sql -h <database-hostname> <dbname>
+--
+-
+--
+-- After deletion of Data Cube Product, records in Cubedash tables are not cleared. Following queries will keep Explorer clean.
+--
+
+--
+-- SELECT/DELETE PRODUCT RECORDS FROM CUBEDASH TABLES
+--
+
+SELECT count(*) FROM cubedash.dataset_spatial WHERE dataset_type_ref=(SELECT id FROM agdc.dataset_type WHERE name=:'product_name');
+
+DELETE FROM cubedash.dataset_spatial WHERE dataset_type_ref=(SELECT id FROM agdc.dataset_type WHERE name=:'product_name');
+
+SELECT count(*) FROM cubedash.time_overview WHERE product_ref=(SELECT id FROM cubedash.product WHERE name = :'product_name');
+
+DELETE FROM cubedash.time_overview WHERE product_ref=(SELECT id FROM cubedash.product WHERE name = :'product_name');
+
+SELECT count(*) FROM cubedash.product WHERE name = :'product_name';
+
+DELETE FROM cubedash.product WHERE name = :'product_name';
+
+SELECT count(*) FROM cubedash.mv_dataset_spatial_quality WHERE dataset_type_ref=(SELECT id FROM agdc.dataset_type WHERE name=:'product_name');
+
+REFRESH MATERIALIZED VIEW CONCURRENTLY cubedash.mv_dataset_spatial_quality;

--- a/odc-product-delete/delete_odc_product_explorer.sql
+++ b/odc-product-delete/delete_odc_product_explorer.sql
@@ -7,7 +7,7 @@
 --
 -- psql -v product_name=<product-to-DELETE> -f delete_product_ows.sql -h <database-hostname> <dbname>
 --
--
+
 --
 -- After deletion of Data Cube Product, records in Cubedash tables are not cleared. Following queries will keep Explorer clean.
 --

--- a/odc-product-delete/delete_odc_product_ows.sql
+++ b/odc-product-delete/delete_odc_product_ows.sql
@@ -1,0 +1,29 @@
+----------------------------------------------------------
+-- SQL to DELETE a Data Cube Product in OWS
+----------------------------------------------------------
+
+--
+-- Use with psql from the command line:
+--
+-- psql -v product_name=<product-to-DELETE> -f delete_product_ows.sql -h <database-hostname> <dbname>
+--
+--
+-- Running delete_odc_product.sql (https://gist.github.com/omad/1ae3463a123f37a9acf37213bebfde86) to delete Data Cube Product fails
+-- when the product has been added in OWS since OWS maintains a foreign key to ODC
+-- psql:DELETE_odc_product.sql:103:
+-- ERROR:  update or DELETE on table "dataset_type" violates foreign key constraint "product_ranges_id_fkey" on table "product_ranges"
+-- DETAIL:  Key (id)=(1) is still referenced from table "product_ranges".
+--
+--To fix the above issue, following queries need to be run before Product deletion.
+--
+-- SELECT/DELETE PRODUCT RECORDS FROM TABLE PRODUCT/SUB PRODUCT RANGES
+
+
+SELECT count(*) FROM wms.product_ranges WHERE id=(SELECT id FROM agdc.dataset_type WHERE name=:'product_name');
+
+DELETE FROM wms.product_ranges WHERE id=(SELECT id FROM agdc.dataset_type WHERE name=:'product_name');
+
+
+SELECT count(*) FROM wms.sub_product_ranges WHERE product_id=(SELECT id FROM agdc.dataset_type WHERE name=:'product_name');
+
+DELETE FROM wms.sub_product_ranges WHERE product_id=(SELECT id FROM agdc.dataset_type WHERE name=:'product_name');

--- a/odc-product-delete/delete_odc_product_ows.sql
+++ b/odc-product-delete/delete_odc_product_ows.sql
@@ -5,19 +5,10 @@
 --
 -- Use with psql from the command line:
 --
--- psql -v product_name=<product-to-DELETE> -f delete_product_ows.sql -h <database-hostname> <dbname>
---
---
--- Running delete_odc_product.sql (https://gist.github.com/omad/1ae3463a123f37a9acf37213bebfde86) to delete Data Cube Product fails
--- when the product has been added in OWS since OWS maintains a foreign key to ODC
--- psql:DELETE_odc_product.sql:103:
--- ERROR:  update or DELETE on table "dataset_type" violates foreign key constraint "product_ranges_id_fkey" on table "product_ranges"
--- DETAIL:  Key (id)=(1) is still referenced from table "product_ranges".
---
---To fix the above issue, following queries need to be run before Product deletion.
+-- psql -v product_name=<product-to-DELETE> -f delete_odc_product_ows.sql -h <database-hostname> <dbname>
 --
 -- SELECT/DELETE PRODUCT RECORDS FROM TABLE PRODUCT/SUB PRODUCT RANGES
-
+--
 
 SELECT count(*) FROM wms.product_ranges WHERE id=(SELECT id FROM agdc.dataset_type WHERE name=:'product_name');
 


### PR DESCRIPTION
SQL scripts to delete ODC products and related records in ODC, Explorer and OWS DB. 

- `delete_odc_product.sql`    
- `delete_odc_product_explorer.sql` 
- `delete_odc_product_ows.sql`