### PR TITLE
Explorer cleanup

### DIFF
--- a/odc-product-delete/README.md
+++ b/odc-product-delete/README.md
@@ -4,6 +4,7 @@
     - `delete_odc_product_ows.sql`
     - `delete_odc_product.sql`
     - `delete_odc_product_explorer.sql`
+    - `cleanup_explorer.sql`
 
 ## WARNING!!!
 - These scripts deletes data, so review the scripts thoroughly and use it very carefully!
@@ -49,7 +50,7 @@ Note: The `delete_odc_product.sql` is sourced from [here](https://gist.github.co
 
 
 
-## Delete ODC Product from ODC DB (`delete_odc_product.sql`)
+## Cleanup explorer from ODC DB (`cleanup_explorer.sql`)
 
 - It deletes records from these tables `cubedash.dataset_spatial` for all dataset_type deleted from ODC DB
 - Then it refreshes materialised view `cubedash.mv_dataset_spatial_quality` as this materialized view directly derives off `cubedash.dataset_spatial`

--- a/odc-product-delete/README.md
+++ b/odc-product-delete/README.md
@@ -33,8 +33,7 @@ psql -v product_name=<product-to-delete> -f <scriptname.sql> -h <database-hostna
 - Before deletion of an product in ODC DB, Explorer's Schema needs to be cleaned as this script makes reference to ODC DB.
 - This script will delete records related to an ODC product from the Explorer Schema in the ODC DB.
 - It unnests the product id `derived_product_refs` and `source_product_refs` columns from `cubedash.product` table
-- It deletes records from these tables `cubedash.region`, `cubedash.dataset_spatial`, `cubedash.time_overview`, `cubedash.product`.
-- Also, it refreshes materialised view `cubedash.mv_dataset_spatial_quality`.
+- It deletes records from these tables `cubedash.region`, `cubedash.time_overview`, `cubedash.product`.
 
 
 ## Delete ODC Product from ODC DB (`delete_odc_product.sql`)
@@ -47,6 +46,14 @@ psql -v product_name=<product-to-delete> -f <scriptname.sql> -h <database-hostna
 - It also deletes indexes and view created for that ODC product.
 
 Note: The `delete_odc_product.sql` is sourced from [here](https://gist.github.com/omad/1ae3463a123f37a9acf37213bebfde86) and additional script to delete index and view are added.
+
+
+
+## Delete ODC Product from ODC DB (`delete_odc_product.sql`)
+
+- It deletes records from these tables `cubedash.dataset_spatial` for all dataset_type deleted from ODC DB
+- Then it refreshes materialised view `cubedash.mv_dataset_spatial_quality` as this materialized view directly derives off `cubedash.dataset_spatial`
+
 
 
 ## Steps to run scripts in sequence
@@ -62,7 +69,10 @@ psql -v product_name=<product-to-delete> -f delete_odc_product_explorer.sql -h <
 ```
 psql -v product_name=<product-to-delete> -f delete_odc_product.sql -h <database-hostname> <dbname>
 ```
-
+- Run `cleanup_explorer.sql` to refresh materialized view for deleted product.
+```
+psql -f cleanup_explorer.sql -h <database-hostname> <dbname>
+```
 ## Detailed Steps to run scripts in sequence
 - setup env
 ```

--- a/odc-product-delete/README.md
+++ b/odc-product-delete/README.md
@@ -98,3 +98,9 @@ export DB_USERNAME=odc_admin
 export DB_PASSWORD=<odc_admin_password>
 PGPASSWORD=$DB_PASSWORD psql -v product_name=<product-to-delete> -f delete_odc_product.sql -h $DB_HOSTNAME $DB_DATABASE -U $DB_USERNAME -p $DB_PORT
 ```
+- Next run `cleanup_explorer.sql` to delete products from Explorer DB.
+```
+export DB_USERNAME=explorer_admin
+export DB_PASSWORD=<explorer_admin_password>
+PGPASSWORD=$DB_PASSWORD psql  -f cleanup_explorer.sql -h $DB_HOSTNAME $DB_DATABASE -U $DB_USERNAME -p $DB_PORT
+```

--- a/odc-product-delete/cleanup_explorer.sql
+++ b/odc-product-delete/cleanup_explorer.sql
@@ -1,0 +1,20 @@
+----------------------------------------------------------
+-- SQL to CLEANUP Explorer
+----------------------------------------------------------
+
+--
+-- Use with psql from the command line:
+--
+-- psql -f delete_product_ows.sql -h <database-hostname> <dbname>
+--
+
+--
+-- After deletion of Data Cube Product, records in Cubedash tables are not cleared. Following queries will keep Explorer clean.
+--
+
+-- delete all entry from dataset_spatial where dataset_type_ref has been deleted in agdc
+delete from cubedash.dataset_spatial where not exists (select id from agdc.dataset_type where id = dataset_type_ref);
+
+-- cubedash.mv_dataset_spatial_quality is directly derived from cubedash.dataset_spatial
+-- run this straight after the deletion
+REFRESH MATERIALIZED VIEW CONCURRENTLY cubedash.mv_dataset_spatial_quality;

--- a/odc-product-delete/delete_odc_product_explorer.sql
+++ b/odc-product-delete/delete_odc_product_explorer.sql
@@ -16,11 +16,6 @@
 -- SELECT/DELETE PRODUCT RECORDS FROM CUBEDASH TABLES
 --
 
-SELECT count(*) FROM cubedash.dataset_spatial WHERE dataset_type_ref=(SELECT id FROM agdc.dataset_type WHERE name=:'product_name');
-
-DELETE FROM cubedash.dataset_spatial WHERE dataset_type_ref=(SELECT id FROM agdc.dataset_type WHERE name=:'product_name');
-
-
 --
 -- for explorer version with region support
 --
@@ -57,8 +52,3 @@ SET    source_product_refs = array_remove(source_product_refs, (
               SELECT id::smallint
               FROM   agdc.dataset_type
               WHERE  NAME=:'product_name')));
-
-
-SELECT count(*) FROM cubedash.mv_dataset_spatial_quality WHERE dataset_type_ref=(SELECT id FROM agdc.dataset_type WHERE name=:'product_name');
-
-REFRESH MATERIALIZED VIEW CONCURRENTLY cubedash.mv_dataset_spatial_quality;


### PR DESCRIPTION
- split current explorer product deletion into two
- the explorer deletion based on product name
- and delete from all deleted dataset after odc deletion is completed and refresh materialized view

related issue: https://github.com/opendatacube/datacube-dataset-config/issues/27