### PR TITLE
new sql script to deep cleanse odc indexes

### DIFF
--- a/odc-product-delete/README.md
+++ b/odc-product-delete/README.md
@@ -5,6 +5,7 @@
     - `delete_odc_product.sql`
     - `delete_odc_product_explorer.sql`
     - `cleanup_explorer.sql`
+    - `cleanup_odc_indexes.sql`
 
 ## WARNING!!!
 - These scripts deletes data, so review the scripts thoroughly and use it very carefully!
@@ -56,6 +57,9 @@ Note: The `delete_odc_product.sql` is sourced from [here](https://gist.github.co
 - Then it refreshes materialised view `cubedash.mv_dataset_spatial_quality` as this materialized view directly derives off `cubedash.dataset_spatial`
 
 
+## Cleanup residue indexes from ODC DB (`cleanup_odc_indexes.sql`)
+
+- It deletes indexes from `pg_indexes` for all dataset_type deleted from ODC DB
 
 ## Steps to run scripts in sequence
 - First, run `delete_odc_product_ows.sql` (optional: this step is not required if the product has not been added to OWS).
@@ -74,8 +78,12 @@ psql -v product_name=<product-to-delete> -f delete_odc_product.sql -h <database-
 ```
 psql -f cleanup_explorer.sql -h <database-hostname> <dbname>
 ```
+- Run `cleanup_odc_indexes.sql` to refresh materialized view for deleted product.
+```
+psql -f cleanup_odc_indexes.sql -h <database-hostname> <dbname>
+```
 ## Detailed Steps to run scripts in sequence
-- setup env
+### setup common env
 ```
 export DB_PORT=5432
 export DB_DATABASE=dbname
@@ -104,4 +112,11 @@ PGPASSWORD=$DB_PASSWORD psql -v product_name=<product-to-delete> -f delete_odc_p
 export DB_USERNAME=explorer_admin
 export DB_PASSWORD=<explorer_admin_password>
 PGPASSWORD=$DB_PASSWORD psql  -f cleanup_explorer.sql -h $DB_HOSTNAME $DB_DATABASE -U $DB_USERNAME -p $DB_PORT
+```
+
+### Ad-hoc / on-demand / as required script
+```
+export DB_USERNAME=odc_admin
+export DB_PASSWORD=<odc_admin_password>
+PGPASSWORD=$DB_PASSWORD psql -f cleanup_odc_indexes.sql -h $DB_HOSTNAME $DB_DATABASE -U $DB_USERNAME -p $DB_PORT
 ```

--- a/odc-product-delete/cleanup_explorer.sql
+++ b/odc-product-delete/cleanup_explorer.sql
@@ -5,7 +5,7 @@
 --
 -- Use with psql from the command line:
 --
--- psql -f delete_product_ows.sql -h <database-hostname> <dbname>
+-- psql -f cleanup_explorer.sql -h <database-hostname> <dbname>
 --
 
 --

--- a/odc-product-delete/cleanup_odc_indexes.sql
+++ b/odc-product-delete/cleanup_odc_indexes.sql
@@ -1,0 +1,36 @@
+----------------------------------------------------------
+-- SQL to CLEANUP ODC Dynamic Indexes
+----------------------------------------------------------
+
+--
+-- Use with psql from the command line:
+--
+-- psql -f cleanup_odc_indexes.sql -h <database-hostname> <dbname>
+--
+
+--
+-- Run as required to cleanup all left-over dynamic indexes
+--
+
+-- delete all entry from dataset_spatial where dataset_type_ref has been deleted in agdc
+set search_path = 'agdc';
+
+SELECT name FROM datset_type;
+
+SELECT format('div_%I_%s', (select name from agdc.dataset_type limit 1), '%');
+
+select pgi.indexname from pg_indexes pgi WHERE pgi.indexname ~ (SELECT name from agdc.dataset_type limit 1);
+
+select substring(indexname, '^dix_(.*?)_lat_lon_time$') from pg_indexes pgi WHERE pgi.indexname LIKE 'dix_%_lat_lon_time';
+
+select name from agdc.dataset_type where name IN (select substring(indexname, '^dix_(.*?)_lat_lon_time$') as index_p_name from pg_indexes pgi WHERE pgi.indexname LIKE 'dix_%_lat_lon_time');
+
+with index_p_name as (select substring(indexname, '^dix_(.*?)_lat_lon_time$') as name from pg_indexes WHERE indexname LIKE 'dix_%_lat_lon_time') select name from index_p_name where name not in (select name from agdc.dataset_type);
+
+with index_p_name as (select substring(indexname, '^dix_(.*?)_instrument$') as name from pg_indexes WHERE indexname LIKE 'dix_%_instrument') select name from index_p_name where name not in (select name from agdc.dataset_type);
+
+with index_p_name as (select substring(indexname, '^dix_(.*?)_platform$') as name from pg_indexes WHERE indexname LIKE 'dix_%_platform') select name from index_p_name where name not in (select name from agdc.dataset_type);
+
+with index_p_name as (select substring(indexname, '^dix_(.*?)_time_lat_lon$') as name from pg_indexes WHERE indexname LIKE 'dix_%_time_lat_lon') select name from index_p_name where name not in (select name from agdc.dataset_type);
+
+with viewcheck as (select substring(viewname, '^dv_(.*?)_dataset$') as vname from pg_catalog.pg_views where viewname LIKE 'dv_%_dataset') select vname from viewcheck where vname not in (select name from agdc.dataset_type);


### PR DESCRIPTION
- checks the list of odc product indexes against the current list of indexes products
- delete the odc product indexes with `no/deleted` product
- update README for future reference
```
(base) ubuntu@:~/datacube-dataset-config/odc-product-delete$ PGPASSWORD=$DB_PASSWORD psql -v product_name=sentinel2_wofs_nrt -f audit_odc_indexes.sql -h $DB_HOSTNAME $DB_DATABASE -U $DB_USERNAME -p $DB_PORT
SET
                              drop_statement                               
---------------------------------------------------------------------------
 DROP INDEX CONCURRENTLY agdc.dix_mangrove_cover_test_time_lat_lon;
 DROP INDEX CONCURRENTLY agdc.dix_mangrove_cover_test_lat_lon_time;
 DROP INDEX CONCURRENTLY agdc.dix_ga_s2bm_fractional_cover_lat_lon_time;
 DROP INDEX CONCURRENTLY agdc.dix_ga_s2bm_fractional_cover_2_lat_lon_time;
(4 rows)

DROP INDEX
DROP INDEX
DROP INDEX
DROP INDEX
```